### PR TITLE
The "# inner rings" count is wrong for two of the polygons?

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ I'd be grateful if you submitted other interesting ones through pull requests.
 | dataset   | total # vertices | # inner rings | # vertices largest ring | source | OGC valid |
 | --------- | ----------------:| -------------:| ------------:| ------ |:---------:|
 | [cleveland](https://github.com/hugoledoux/BIGpolygons/blob/master/cleveland.geojson) |  1,689,703 |  66,908 |  500,373  | [Cleveland Metroparks](http://clevelandmetroparks.com)                             | false     |
-| [EU-199948](https://github.com/hugoledoux/BIGpolygons/blob/master/EU-199948.geojson) |  1,189,903 |   7,672 |  280,150  | [Corine land cover](http://www.eea.europa.eu/data-and-maps/data/clc-2006-vector-data-version-2)    | false     |
+| [EU-199948](https://github.com/hugoledoux/BIGpolygons/blob/master/EU-199948.geojson) |  1,189,903 |   7,671 |  280,150  | [Corine land cover](http://www.eea.europa.eu/data-and-maps/data/clc-2006-vector-data-version-2)    | false     |
 | [russia](https://github.com/hugoledoux/BIGpolygons/blob/master/russia.geojson)       |    283,515 |       0 |  283,515  | [Large Scale International Boundary Lines ](https://hiu.state.gov/data/)           | true      |
 | [canada](https://github.com/hugoledoux/BIGpolygons/blob/master/canada.geojson)       |    193,279 |       0 |  193,279  | [Large Scale International Boundary Lines ](https://hiu.state.gov/data/)           | true      |
 | [085M](https://github.com/hugoledoux/BIGpolygons/blob/master/085M.geojson)           |    192,355 |   7,684 |   39,067  | [Canada Land Cover](http://www.geobase.ca/geobase/en/data/landcover/index.html)    | false     |
 | [021L](https://github.com/hugoledoux/BIGpolygons/blob/master/021L.geojson)           |    148,612 |   5,132 |   34,471  | [Canada Land Cover](http://www.geobase.ca/geobase/en/data/landcover/index.html)    | false     |
-| [EU-180927](https://github.com/hugoledoux/BIGpolygons/blob/master/EU-180927.geojson) |    102,272 |     299 |   63,346  | [Corine land cover](http://www.eea.europa.eu/data-and-maps/data/clc-2006-vector-data-version-2)    | false     |
+| [EU-180927](https://github.com/hugoledoux/BIGpolygons/blob/master/EU-180927.geojson) |    102,272 |     298 |   63,346  | [Corine land cover](http://www.eea.europa.eu/data-and-maps/data/clc-2006-vector-data-version-2)    | false     |


### PR DESCRIPTION
I'm working on adding a simplistic GeoJSON parser to the Apache Lucene project, and was using these delightful polygons to test my parser, but found that the inner ring count I was seeing was off by one for two of the polygons.

I dug further (made a Python script to separately count them) and I think the `REAMDE.md` is just wrong for these two.
